### PR TITLE
Updating with support for cookies that are HttpOnly.

### DIFF
--- a/cookiefile.go
+++ b/cookiefile.go
@@ -81,14 +81,26 @@ func isWhitespaceAscii(r rune) bool {
 }
 
 func parseLine(line string) (*http.Cookie, error) {
-	if "" == strings.TrimFunc(line, isWhitespaceAscii) || '#' == strings.TrimLeftFunc(line, isWhitespaceAscii)[0] {
+	if "" == strings.TrimFunc(line, isWhitespaceAscii) {
 		return nil, nil
 	}
+
+	if '#' == strings.TrimLeftFunc(line, isWhitespaceAscii)[0] && !strings.HasPrefix(line, "#HttpOnly_") {
+	    return nil, nil
+	}
+
+	cookie := &http.Cookie{}
+
+	if strings.HasPrefix(line, "#HttpOnly_") {
+	    cookie.HttpOnly = true
+
+	    line = strings.TrimPrefix(line, "#HttpOnly_")
+	}
+
 	entries := strings.Split(line, "\t")
 	if len(entries) != 7 {
 		return nil, fmt.Errorf("Invalid amount of fields")
 	}
-	cookie := &http.Cookie{}
 
 	/*set domain*/
 	if err := validateDomain(entries[0]); err != nil {

--- a/cookiefile_test.go
+++ b/cookiefile_test.go
@@ -3,6 +3,7 @@
 package cookiefile
 
 import (
+	"fmt"
 	"net/url"
 	"testing"
 )
@@ -22,11 +23,14 @@ func TestLoadJar(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	addr, err := url.Parse("http://example.net")
-	if err != nil {
-		t.Error(err)
-	}
-	if len(jar.Cookies(addr)) != 1 {
-		t.Errorf("Expected 1 cookie for host %q, got %d", addr.Hostname(), len(jar.Cookies(addr)))
+
+	for _, host := range []string{"example.net", "httponly.net"} {
+		addr, err := url.Parse(fmt.Sprintf("http://%s", host))
+		if err != nil {
+			t.Error(err)
+		}
+		if len(jar.Cookies(addr)) != 1 {
+			t.Errorf("Expected 1 cookie for host %q, got %d", addr.Hostname(), len(jar.Cookies(addr)))
+		}
 	}
 }

--- a/test/valid.txt
+++ b/test/valid.txt
@@ -2,4 +2,5 @@
 # https://curl.haxx.se/rfc/cookie_spec.html
 
 .example.net	TRUE	/	FALSE	2146723199	test	testvalue
+#HttpOnly_.httponly.net	TRUE	/	FALSE	2146723199	test	testvalue
 subdomain.example.net	TRUE	/foo/bar	FALSE	2014934927	foo	bar


### PR DESCRIPTION
I've added support for HttpOnly cookies per the spec here https://curl.se/docs/http-cookies.html.